### PR TITLE
Update to support Pharo 9

### DIFF
--- a/repository/Tealight-Web-Tools/TLRESTAPIBuilder.class.st
+++ b/repository/Tealight-Web-Tools/TLRESTAPIBuilder.class.st
@@ -15,7 +15,7 @@ TLRESTAPIBuilder class >> allPragmas [
 	
 	|col|
 	col := (PragmaCollector new
-				filter: [ :prg | prg keyword = self pragmaKeyword ])
+				filter: [ :prg | prg selector = self pragmaKeyword ])
 				reset.
 	^col collected
 


### PR DESCRIPTION
Pragma uses `selector` instead of `keyword` in Pharo 9

Maybe the idea is to create a version for Pharo8 and older; and another one for Pharo9 and later