### PR TITLE
Feature/TLRESTAPIBuilder refactoring

### DIFF
--- a/repository/Tealight-Web-Tools/TLRESTAPIBuilder.class.st
+++ b/repository/Tealight-Web-Tools/TLRESTAPIBuilder.class.st
@@ -12,6 +12,13 @@ Class {
 	#category : #'Tealight-Web-Tools-REST-API-Building'
 }
 
+{ #category : #accessing }
+TLRESTAPIBuilder class >> allPragmas [
+	"Return a collection of all the REST API pragmas"
+	
+	^ (PragmaCollector selectors: {self pragmaKeyword}) pragmas
+]
+
 { #category : #building }
 TLRESTAPIBuilder class >> buildAPI [
 	"Build the API from the receiver and subclasses"
@@ -55,9 +62,8 @@ TLRESTAPIBuilder class >> teapotRefreshed [
 
 { #category : #accessing }
 TLRESTAPIBuilder >> allPragmas [
-	"Return a collection of all the REST API pragmas"
 	
-	^ (PragmaCollector selectors: {self pragmaKeyword}) pragmas
+	^ self class allPragmas
 ]
 
 { #category : #building }

--- a/repository/Tealight-Web-Tools/TLRESTAPIBuilder.class.st
+++ b/repository/Tealight-Web-Tools/TLRESTAPIBuilder.class.st
@@ -6,35 +6,74 @@ A simple utility class to build a REST API from methods
 Class {
 	#name : #TLRESTAPIBuilder,
 	#superclass : #Object,
-	#category : 'Tealight-Web-Tools-REST-API-Building'
+	#instVars : [
+		'teapot'
+	],
+	#category : #'Tealight-Web-Tools-REST-API-Building'
 }
-
-{ #category : #'private - accessing' }
-TLRESTAPIBuilder class >> allPragmas [
-	"Return a collection of all the REST API pragmas"
-	
-	^ (PragmaCollector selectors: {self pragmaKeyword}) pragmas
-]
-
-{ #category : #'private - building' }
-TLRESTAPIBuilder class >> build [
-	"Build a regular API (unversioned) by installing a teapot route for each pragma definition"
-
-	self allPragmas do: [ :each | 
-			self installHook: each arguments first path: (self pathFromPragma: each) pragma: each ]
-]
 
 { #category : #building }
 TLRESTAPIBuilder class >> buildAPI [
 	"Build the API from the receiver and subclasses"
 	<script>
 	
-	self withAllSubclassesDo: [:each | each build ]
-
+	self buildAPIFor: self teapotRefreshed
 ]
 
-{ #category : #'private - utilities' }
-TLRESTAPIBuilder class >> installHook: httpMethod path: aPath pragma: aPragma [
+{ #category : #building }
+TLRESTAPIBuilder class >> buildAPIFor: aTeapot [
+
+	"Build the API from the receiver and subclasses"
+
+	<script>
+	self withAllSubclassesDo: [ :each | (each on: aTeapot) build ]
+]
+
+{ #category : #'instance creation' }
+TLRESTAPIBuilder class >> on: aTeapot [
+	^ self new teapot: aTeapot; yourself
+]
+
+{ #category : #accessing }
+TLRESTAPIBuilder class >> pragmaKeyword [
+	"Return the Pragma keyword that is used to define a REST API"
+	
+	^#REST_API:pattern:
+]
+
+{ #category : #accessing }
+TLRESTAPIBuilder class >> teapot [
+
+	^TLWebserver teapot
+]
+
+{ #category : #accessing }
+TLRESTAPIBuilder class >> teapotRefreshed [
+
+	^TLWebserver teapotRefreshed 
+]
+
+{ #category : #accessing }
+TLRESTAPIBuilder >> allPragmas [
+	"Return a collection of all the REST API pragmas"
+	
+	^ (PragmaCollector selectors: {self pragmaKeyword}) pragmas
+]
+
+{ #category : #building }
+TLRESTAPIBuilder >> build [
+
+	"Build a regular API (unversioned) by installing a teapot route for each pragma definition"
+
+	self allPragmas do: [ :each | 
+		self
+			installHook: each arguments first
+			path: (self pathFromPragma: each)
+			pragma: each ]
+]
+
+{ #category : #installing }
+TLRESTAPIBuilder >> installHook: httpMethod path: aPath pragma: aPragma [
 
 	"Install a dynamic route as a hook in the current teapot"
 
@@ -46,27 +85,31 @@ TLRESTAPIBuilder class >> installHook: httpMethod path: aPath pragma: aPragma [
 	self teapot perform: (httpMethod , ':') asSymbol with: route
 ]
 
-{ #category : #'private - accessing' }
-TLRESTAPIBuilder class >> newPathBuilder [
+{ #category : #'private - factory' }
+TLRESTAPIBuilder >> newPathBuilder [
 	^ TLRESTApiURLPathBuilder new
 ]
 
 { #category : #'private - utilities' }
-TLRESTAPIBuilder class >> pathFromPragma: aPragma [
+TLRESTAPIBuilder >> pathFromPragma: aPragma [
 	^(self newPathBuilder)			
 			function: aPragma arguments second;
 			path
 ]
 
-{ #category : #'private - accessing' }
-TLRESTAPIBuilder class >> pragmaKeyword [
-	"Return the Pragma keyword that is used to define a REST API"
-	
-	^#REST_API:pattern:
+{ #category : #accessing }
+TLRESTAPIBuilder >> pragmaKeyword [
+	^ self class pragmaKeyword
 ]
 
-{ #category : #'private - accessing' }
-TLRESTAPIBuilder class >> teapot [
+{ #category : #accessing }
+TLRESTAPIBuilder >> teapot [
 
-	^TLWebserver teapot 
+	^ teapot
+]
+
+{ #category : #accessing }
+TLRESTAPIBuilder >> teapot: anObject [
+
+	teapot := anObject
 ]

--- a/repository/Tealight-Web-Tools/TLVersionedRESTAPIBuilder.class.st
+++ b/repository/Tealight-Web-Tools/TLVersionedRESTAPIBuilder.class.st
@@ -4,11 +4,18 @@ An API builder for a versioned REST API
 Class {
 	#name : #TLVersionedRESTAPIBuilder,
 	#superclass : #TLRESTAPIBuilder,
-	#category : 'Tealight-Web-Tools-REST-API-Building'
+	#category : #'Tealight-Web-Tools-REST-API-Building'
 }
 
-{ #category : #'private - building' }
-TLVersionedRESTAPIBuilder class >> build [
+{ #category : #accessing }
+TLVersionedRESTAPIBuilder class >> pragmaKeyword [
+	"Return the Pragma keyword that is used to define a versioned REST API"
+	
+	^#REST_API:versions:pattern:
+]
+
+{ #category : #building }
+TLVersionedRESTAPIBuilder >> build [
 	"Build a regular API (unversioned) by installing a teapot route for each pragma definition"
 
 	self allPragmas do: [ :each | 
@@ -17,7 +24,7 @@ TLVersionedRESTAPIBuilder class >> build [
 ]
 
 { #category : #'private - utilities' }
-TLVersionedRESTAPIBuilder class >> pathFromPragma: aPragma [
+TLVersionedRESTAPIBuilder >> pathFromPragma: aPragma [
 	^(self newPathBuilder)			
 			version: aPragma arguments second;
 			function: aPragma arguments third;
@@ -25,23 +32,9 @@ TLVersionedRESTAPIBuilder class >> pathFromPragma: aPragma [
 ]
 
 { #category : #'private - utilities' }
-TLVersionedRESTAPIBuilder class >> pathFromPragma: aPragma version: aVersion [
+TLVersionedRESTAPIBuilder >> pathFromPragma: aPragma version: aVersion [
 	^(self newPathBuilder)			
 			version: aVersion;
 			function: aPragma arguments third;
 			path
-]
-
-{ #category : #'private - accessing' }
-TLVersionedRESTAPIBuilder class >> pragmaKeyword [
-	"Return the Pragma keyword that is used to define a versioned REST API"
-	
-	^#REST_API:versions:pattern:
-]
-
-{ #category : #'private - accessing' }
-TLVersionedRESTAPIBuilder >> pragmaKeyword [
-	"Return the Pragma keyword that is used to define a REST API"
-	
-	^#REST_API:versions:pattern:
 ]

--- a/repository/Tealight-Web-Tools/TLWebserver.class.st
+++ b/repository/Tealight-Web-Tools/TLWebserver.class.st
@@ -11,7 +11,7 @@ Class {
 		'DefaultPort',
 		'DefaultServer'
 	],
-	#category : 'Tealight-Web-Tools-Runtime'
+	#category : #'Tealight-Web-Tools-Runtime'
 }
 
 { #category : #operating }
@@ -75,6 +75,12 @@ TLWebserver class >> teapot [
 	^self defaultServer teapot
 ]
 
+{ #category : #accessing }
+TLWebserver class >> teapotRefreshed [
+
+	^self defaultServer refreshTeapot
+]
+
 { #category : #'private - initialization' }
 TLWebserver >> initTeapot [
 
@@ -88,6 +94,13 @@ TLWebserver >> initialize [
 
 	super initialize.
 	self initTeapot
+]
+
+{ #category : #initialization }
+TLWebserver >> refreshTeapot [
+	self teapot server isRunning ifTrue: [ self stop ].
+	self initTeapot.
+	^ self teapot
 ]
 
 { #category : #running }


### PR DESCRIPTION
Currently evaluating `TLRESTAPIBuilder buildAPI` twice causes redundant routings in `TLWebserver teapot` instance (two 'api/hello' entries, for example). 
So I changed to refresh the default server's teapot routes each time when #buildAPI called. 
Now we do not have to evaluate
`TLWebserver teapot removeAllDynamicRoutes` explicitly.
Please consider merging the PR.

- TLRESTAPIBuilder class >> buildAPI is now idempotent.
- Changed TLRESTAPIBuilder most class methods to instance methods.
- Added TLRESTAPIBuilder class >> buildAPIFor: aTeapot for passing an arbitrary teapot instance.